### PR TITLE
docs: Update project vision with WordOtter branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ A comprehensive vocabulary learning application that aggregates interesting word
 
 VocabBuilder is designed to be an extensible vocabulary aggregation platform. Currently, it supports scraping from the "A Word A Day" (AWAD) website at wordsmith.org, with plans to integrate multiple vocabulary sources including dictionary APIs, literature databases, and other educational resources.
 
+## Vision
+
+Some people collect stamps or pressed flowers. We collect words. Not in haste, but in the way you might collect seashells on a quiet morning—turning each one over, marveling at its shape, feeling the weight of its history.
+
+WordOtter is for those who find joy in this kind of lingering. It's for people who read a sentence twice, not because they didn't understand it, but because it felt too good to leave behind. For those who smile when they meet sonder or halcyon in the wild, and tuck it away for later use.
+
+We believe words are not mere instruments of communication—they are the tools with which we think, dream, and build the architecture of our inner worlds. Learning them should feel less like homework and more like stepping into a well-lit room you didn't know was in your own home.
+
+Here you'll find:
+
+- **A Curated Lexicon** of words worth keeping
+- **Precise Definitions** paired with examples drawn from literature and real life
+- **Interactive Study Tools** that make practice a pleasure
+- **Free & Open Access** for anyone with curiosity and a few spare minutes
+
+For the word-lover, this is a homecoming. For everyone else, perhaps, the beginning of an unexpected romance.
+
 ## Current Features
 
 ### Wordsmith.org Integration

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,12 @@
-# VocabBuilder Roadmap
+# WordOtter Roadmap
 
 ## Project Vision
 
-VocabBuilder aims to become a comprehensive vocabulary learning tool that aggregates interesting words from multiple sources, making vocabulary expansion accessible and enjoyable.
+Some people collect stamps or pressed flowers. We collect words. Not in haste, but in the way you might collect seashells on a quiet morning—turning each one over, marveling at its shape, feeling the weight of its history.
+
+WordOtter is for those who find joy in this kind of lingering. It's for people who read a sentence twice, not because they didn't understand it, but because it felt too good to leave behind. For those who smile when they meet sonder or halcyon in the wild, and tuck it away for later use.
+
+We believe words are not mere instruments of communication—they are the tools with which we think, dream, and build the architecture of our inner worlds. Learning them should feel less like homework and more like stepping into a well-lit room you didn't know was in your own home.
 
 ## Current Status (August 2024)
 
@@ -67,7 +71,7 @@ VocabBuilder aims to become a comprehensive vocabulary learning tool that aggreg
 
 ## Contributing
 
-VocabBuilder is open to contributions! Areas where help is particularly welcome:
+WordOtter is open to contributions! Areas where help is particularly welcome:
 
 - Adding new data source integrations
 - Improving word extraction accuracy

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -11,7 +11,11 @@
     <div class="about-content">
         <section class="about-section">
             <h2>📚 Our Mission</h2>
-            <p>VocabBuilder is dedicated to helping people expand their vocabulary through carefully curated words from various sources. We believe that a rich vocabulary enhances communication, comprehension, and cognitive abilities.</p>
+            <p>Some people collect stamps or pressed flowers. We collect words. Not in haste, but in the way you might collect seashells on a quiet morning—turning each one over, marveling at its shape, feeling the weight of its history.
+
+WordOtter is for those who find joy in this kind of lingering. It's for people who read a sentence twice, not because they didn't understand it, but because it felt too good to leave behind. For those who smile when they meet sonder or halcyon in the wild, and tuck it away for later use.
+
+We believe words are not mere instruments of communication—they are the tools with which we think, dream, and build the architecture of our inner worlds. Learning them should feel less like homework and more like stepping into a well-lit room you didn't know was in your own home.</p>
         </section>
 
         <section class="about-section">


### PR DESCRIPTION
## Summary

This PR updates the project vision across documentation files with a poetic narrative that captures the essence of WordOtter as a thoughtful vocabulary learning platform.

## Changes Made

### 📝 Files Modified (3 files only)
- **README.md**: Added new Vision section after Overview
- **docs/roadmap.md**: Updated Project Vision with WordOtter branding  
- **web/templates/about.html**: Replaced Our Mission content with new vision text

### ✨ Vision Update
The new vision emphasizes:
- The joy of collecting and discovering words
- WordOtter as a tool for language enthusiasts
- Words as tools for thinking, dreaming, and building inner worlds
- Learning vocabulary as pleasant discovery rather than homework

## The Vision Text

> Some people collect stamps or pressed flowers. We collect words. Not in haste, but in the way you might collect seashells on a quiet morning—turning each one over, marveling at its shape, feeling the weight of its history.
>
> WordOtter is for those who find joy in this kind of lingering. It's for people who read a sentence twice, not because they didn't understand it, but because it felt too good to leave behind. For those who smile when they meet sonder or halcyon in the wild, and tuck it away for later use.
>
> We believe words are not mere instruments of communication—they are the tools with which we think, dream, and build the architecture of our inner worlds. Learning them should feel less like homework and more like stepping into a well-lit room you didn't know was in your own home.

## Important Note
✅ This PR contains **ONLY** documentation/vision text updates  
❌ No styling, color, or font changes included  
❌ No additional files or assets

## Testing
- Vision text renders correctly on the About page
- Markdown formatting preserved in all documentation files
- HTML structure maintained in templates